### PR TITLE
Disambiguate MongoDB -> MongoDB (inc) Atlas service.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # Rongo
-MongoDB API Wrapper for Roblox!
+MongoDB Atlas API Wrapper for Roblox!
 
 [**DevForum Post & Documentation**](https://devforum.roblox.com/t/rongo/1755615)

--- a/src/Rongo.lua
+++ b/src/Rongo.lua
@@ -1,9 +1,10 @@
 --[[
 
-	Rongo - MongoDB API Wrapper for Roblox
+	Rongo - MongoDB Atlas API Wrapper for Roblox
 	
-	Rongo gives developers easy access to MongoDBs web APIs
-	so they're able to use MongoDB directly in their games
+	Rongo gives developers easy access to MongoDB Atlas web 
+	APIs so they're able to use Atlas databases directly in 
+	their games.
 	
 	Rongo is a bare-bones module, meaning it contains only
 	the essentials, which can be used standalone or to
@@ -12,8 +13,8 @@
 	Some modules which use Rongo can be found on the Rongo
 	DevForum post!
 	
-	Rongo uses MongoDB's Data API, which is disabled by
-	default so you must enable it in your Atlas settings
+	Rongo uses the Atlas Data API, which is disabled by
+	default, so you must enable it in your Atlas settings.
 	
 	Version: 1.1.0
 	License: MIT License


### PR DESCRIPTION
`MongoDB` refers to the MongoDB server software, which is entirely separate from Atlas, the Mongo company's cloud database solution. This PR disambiguates them, as this project *cannot* interact with non-Atlas databases.

I highly recommend you edit your devforum post to reflect this, as to not confuse new developers.