### PR TITLE
rojo fix - wally fix

### DIFF
--- a/default.project.json
+++ b/default.project.json
@@ -1,0 +1,6 @@
+{
+  "name": "rongo",
+  "tree": {
+    "$path": "src"
+  }
+}


### PR DESCRIPTION
wally requires a script in PATH["rojo"] so we must make src rename itself and turn src folder into a script.

We can do this by:
 - telling rojo reads ./src as "rongo"
 - renaming rojo.lua to init.lua (turns the parent folder into a script containing the code of init.lua)