### PR TITLE
fix: package no longer errors with rojo 7.4.1

### DIFF
--- a/default.project.json
+++ b/default.project.json
@@ -1,6 +1,6 @@
 {
 	"name": "rongo",
 	"tree": {
-		"$path": "src/init.luau"
+		"$path": "src"
 	}
 }

--- a/wally.toml
+++ b/wally.toml
@@ -1,10 +1,9 @@
 [package]
 name = "starnamics/rongo"
 description = "MongoDB Atlas Data API wrapper for connecting Roblox to MongoDB"
-version = "2.1.1"
+version = "2.1.2"
 license = "MIT"
 realm = "server"
 registry = "https://github.com/UpliftGames/wally-index"
-exclude = [
-  "LICENSE", "README.md"
-]
+exclude = ["**"]
+include = ["src", "src/**", "default.project.json", "wally.toml"]


### PR DESCRIPTION
* The package was erroring with Rojo version 7.4.1, I have made the appropriate changes to fix this.
* Cleaned up the Wally file as well to exclude unnecessary files in the package.